### PR TITLE
Allow numeric segment names

### DIFF
--- a/src/tokens.test.ts
+++ b/src/tokens.test.ts
@@ -1156,4 +1156,20 @@ describe("serializeDesignTokens", () => {
     const serialized = serializeDesignTokens(nodesToMap(parsed.nodes));
     expect(serialized).toEqual(input);
   });
+
+  test("allow numeric segment names", () => {
+    const result = parseDesignTokens({
+      color: {
+        $type: "color",
+        blue: {
+          "500": {
+            $value: { colorSpace: "srgb", components: [0, 0, 1] },
+          },
+        },
+        alias: { $value: "{color.blue.500}" },
+      },
+    });
+    expect(result.errors).toHaveLength(0);
+    expect(result.nodes).toHaveLength(4);
+  });
 });

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -38,7 +38,7 @@ const isTokenReference = (value: unknown): value is string => {
     return false;
   }
   // Check if value matches the reference syntax: {group.token} or {group.nested.token}
-  return /^\{[a-zA-Z_$][a-zA-Z0-9_$]*(\.[a-zA-Z_$][a-zA-Z0-9_$]*)*\}$/.test(
+  return /^\{[a-zA-Z0-9_$][a-zA-Z0-9_$-]*(\.[a-zA-Z0-9_$][a-zA-Z0-9_$-]*)*\}$/.test(
     value,
   );
 };


### PR DESCRIPTION
I'd say because JSON keys can be numeric like `"500"` this should be allowed. Also since I think it's common to name tokens like `blue.500` this is nice to support.