### PR TITLE
Add UI to navigate and manage modifiers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,38 +1,157 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Engramma - design tokens app</title>
-    <meta
-      name="description"
-      content="An app to manage standard based design tokens and convert them to CSS or SCSS variables"
-    />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://engramma.dev/" />
-    <meta property="og:image" content="./logo.png" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <link rel="stylesheet" href="./src/app.css" />
-    <!-- Privacy-friendly analytics by Plausible -->
-    <script
-      async
-      src="https://plausible.io/js/pa-lqFhwhQS8pPxKZ9mW4uH-.js"
-    ></script>
-    <script>
-      ((window.plausible =
-        window.plausible ||
-        function () {
-          (plausible.q = plausible.q || []).push(arguments);
-        }),
-        (plausible.init =
-          plausible.init ||
-          function (i) {
-            plausible.o = i || {};
-          }));
-      plausible.init();
-    </script>
-  </head>
-  <body>
-    <script type="module" src="./src/main.ts"></script>
-  </body>
-</html>
+<style>
+  body {
+    background-color: black;
+    font-family: sans-serif;
+    display: grid;
+    height: 100%;
+    height: stretch;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .nav {
+    border: 1px solid #585a5e;
+    width: 60dvw;
+    margin: 0 auto;
+    border-radius: 2rem;
+  }
+
+  .menu {
+    color: gray;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    justify-content: end;
+    padding: 0 1rem;
+  }
+
+  .item {
+    position: relative;
+  }
+
+  @keyframes bounce {
+    from {
+      translate: 0 30px;
+    }
+    80% {
+      scale: 1.2;
+    }
+    to {
+      scale: 1;
+      translate: 0 0px;
+    }
+  }
+
+  @keyframes bounceIn {
+    0% {
+      scale: 1;
+      translate: 0 30px;
+    }
+    40% {
+      scale: 1.2;
+      translate: 0 0;
+    }
+    60% {
+      scale: 0.95;
+    }
+    80% {
+      scale: 1.05;
+    }
+    100% {
+      scale: 1;
+      translate: 0 0;
+    }
+  }
+
+  @keyframes bounceOut {
+    0% {
+      scale: 1;
+      translate: 0 0;
+    }
+    40% {
+      scale: 0.9;
+      translate: 0 30px;
+    }
+    60% {
+      scale: 1.02;
+    }
+    80% {
+      scale: 0.98;
+    }
+    100% {
+      scale: 1;
+      translate: 0 30px;
+    }
+  }
+
+  .item::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -1px;
+    width: 100px;
+    height: 30px;
+    margin: 0 auto;
+    background-color: white;
+    pointer-events: none;
+    clip-path: path("M0,30 S-20,30,0,30 S30,15,50,15 S80,30,100,30 Z");
+    translate: 0 30px;
+    transform-origin: center bottom;
+  }
+
+  .item:has(.link:target)::before {
+    translate: 0 0;
+  }
+
+  .item:has(.link.ready)::before {
+    animation: bounceOut 0.8s ease forwards;
+  }
+
+  .item:has(.link.ready:target)::before {
+    animation: bounceIn 0.8s ease forwards;
+  }
+
+  .link {
+    color: inherit;
+    text-decoration: none;
+    display: block;
+    padding: 2rem 1.5rem;
+  }
+
+  .link:hover,
+  .link:focus-visible,
+  .link:target {
+    color: #2b75ed;
+  }
+
+  .content {
+    background-color: white;
+    border-radius: 2rem;
+    height: 300px;
+  }
+</style>
+
+<nav class="nav">
+  <ul class="menu">
+    <li class="item">
+      <a class="link" id="item-1" href="#item-1">Menu Item</a>
+    </li>
+    <li class="item">
+      <a class="link" id="item-2" href="#item-2">Menu Item</a>
+    </li>
+  </ul>
+  <div class="content"></div>
+</nav>
+
+<script>
+  // activate
+  document.addEventListener("click", (event) => {
+    if (event.target.closest(".link")) {
+      for (const link of document.querySelectorAll(".link")) {
+        link.classList.add("ready");
+      }
+    }
+  });
+</script>

--- a/src/app.css
+++ b/src/app.css
@@ -359,4 +359,10 @@ body {
       anchor-name: --a-selected-tab;
     }
   }
+
+  .a-tab-action {
+    position: sticky;
+    right: 8px;
+    margin: 0 8px;
+  }
 }

--- a/src/app.svelte
+++ b/src/app.svelte
@@ -40,6 +40,8 @@
     Paintbrush,
     Tags,
     ListPlus,
+    Layers,
+    GitBranch,
   } from "@lucide/svelte";
   import TreeView, { type TreeItem } from "./tree-view.svelte";
   import Editor from "./editor.svelte";
@@ -62,6 +64,9 @@
   let appElement: undefined | HTMLDivElement;
   const zeroIndex = generateKeyBetween(null, null);
 
+  let selectedContextId = $state<string | undefined>(undefined);
+  let isConfiguringModifiers = $state(false);
+
   onMount(() => {
     return startKeyUX(window, [
       hotkeyKeyUX([hotkeyMacCompat()]),
@@ -72,8 +77,11 @@
   const rootNodes = $derived(
     treeState
       .getChildren(undefined)
-      // @todo temporary render only token-set
-      .filter((item) => item.meta.nodeType === "token-set"),
+      .filter((item) =>
+        isConfiguringModifiers
+          ? item.meta.nodeType === "token-modifier"
+          : item.meta.nodeType === "token-set",
+      ),
   );
 
   // svelte-ignore state_referenced_locally
@@ -96,6 +104,22 @@
     // svelte-ignore state_referenced_locally
     rootNodes.length ? [rootNodes[0].nodeId] : [],
   );
+
+  const allContexts = $derived.by(() => {
+    const contexts: Array<{ nodeId: string; name: string }> = [];
+    const rootNodes = treeState.getChildren(undefined);
+    for (const node of rootNodes) {
+      if (node.meta.nodeType === "token-modifier") {
+        const modifierChildren = treeState.getChildren(node.nodeId);
+        for (const child of modifierChildren) {
+          if (child.meta.nodeType === "token-context") {
+            contexts.push({ nodeId: child.nodeId, name: child.meta.name });
+          }
+        }
+      }
+    }
+    return contexts;
+  });
 
   const handleDelete = () => {
     if (selectedItems.size === 0) {
@@ -126,65 +150,96 @@
     }
   };
 
-  const handleAddSet = () => {
-    // Token-sets can only be at the top level
-    const rootChildren = treeState.getChildren(undefined);
-    const lastChildIndex = rootChildren.at(-1)?.index ?? zeroIndex;
-    const insertAfterIndex = generateKeyBetween(lastChildIndex, null);
-    const newSet: TreeNode<TreeNodeMeta> = {
-      nodeId: crypto.randomUUID(),
-      parentId: undefined,
-      index: insertAfterIndex,
-      meta: {
-        nodeType: "token-set",
-        name: "New Set",
-      },
-    };
-    treeState.transact((tx) => {
-      tx.set(newSet);
-    });
-    selectedItems.clear();
-    selectedItems.add(newSet.nodeId);
-  };
-
-  const handleAddGroup = () => {
+  const addNode = (config: {
+    nodeType: TreeNodeMeta["nodeType"];
+    parentTypes: TreeNodeMeta["nodeType"][];
+    defaultName: string;
+  }) => {
     const firstSelectedId = Array.from(selectedItems)[0];
     const firstSelectedNode = treeState.getNode(firstSelectedId);
-    if (!firstSelectedNode) {
-      return;
-    }
-    // determine parent and index for new group
+
     let parentId: string | undefined;
     let insertAfterIndex: string;
-    if (
-      firstSelectedNode.meta.nodeType === "token-set" ||
-      firstSelectedNode.meta.nodeType === "token-group"
-    ) {
-      parentId = firstSelectedId;
-      // add at the end of the group
-      const children = treeState.getChildren(firstSelectedId);
-      const lastChildIndex = children.at(-1)?.index ?? zeroIndex;
+
+    if (config.parentTypes.length === 0) {
+      // Root level node (token-set, token-modifier)
+      const rootChildren = treeState.getChildren(undefined);
+      const lastChildIndex = rootChildren.at(-1)?.index ?? zeroIndex;
       insertAfterIndex = generateKeyBetween(lastChildIndex, null);
+      parentId = undefined;
     } else {
-      // add after the token
-      parentId = firstSelectedNode.parentId;
-      insertAfterIndex = generateKeyBetween(firstSelectedNode.index, null);
+      // Child node - needs a parent from allowed types
+      if (!firstSelectedNode) {
+        return;
+      }
+
+      const selectedType = firstSelectedNode.meta.nodeType;
+
+      if (config.parentTypes.includes(selectedType)) {
+        // Add as child of selected node
+        parentId = firstSelectedId;
+        const children = treeState.getChildren(firstSelectedId);
+        const lastChildIndex = children.at(-1)?.index ?? zeroIndex;
+        insertAfterIndex = generateKeyBetween(lastChildIndex, null);
+      } else if (
+        firstSelectedNode.parentId &&
+        config.parentTypes.includes(
+          treeState.getNode(firstSelectedNode.parentId)?.meta.nodeType!,
+        )
+      ) {
+        // Add as sibling after selected node (same parent)
+        parentId = firstSelectedNode.parentId;
+        insertAfterIndex = generateKeyBetween(firstSelectedNode.index, null);
+      } else {
+        // Cannot add here
+        return;
+      }
     }
-    const newGroup: TreeNode<TreeNodeMeta> = {
+
+    const newNode: TreeNode<TreeNodeMeta> = {
       nodeId: crypto.randomUUID(),
       parentId,
       index: insertAfterIndex,
       meta: {
-        nodeType: "token-group",
-        name: "New Group",
-      },
+        nodeType: config.nodeType,
+        name: config.defaultName,
+      } as TreeNodeMeta,
     };
+
     treeState.transact((tx) => {
-      tx.set(newGroup);
+      tx.set(newNode);
     });
     selectedItems.clear();
-    selectedItems.add(newGroup.nodeId);
+    selectedItems.add(newNode.nodeId);
   };
+
+  const addSet = () =>
+    addNode({
+      nodeType: "token-set",
+      parentTypes: [],
+      defaultName: "New Set",
+    });
+
+  const addGroup = () =>
+    addNode({
+      nodeType: "token-group",
+      parentTypes: ["token-set", "token-group"],
+      defaultName: "New Group",
+    });
+
+  const addModifier = () =>
+    addNode({
+      nodeType: "token-modifier",
+      parentTypes: [],
+      defaultName: "New Modifier",
+    });
+
+  const addContext = () =>
+    addNode({
+      nodeType: "token-context",
+      parentTypes: ["token-modifier"],
+      defaultName: "New Context",
+    });
 
   const handleTokenAdded = (tokenNodeId: string) => {
     // select and open editor for the new token
@@ -217,12 +272,42 @@
     newParentId: undefined | string,
     position: number,
   ) => {
-    // Validate that token-sets can only be at top level
+    // Validate move constraints based on node types
     for (const itemId of itemIds) {
       const node = treeState.getNode(itemId);
-      if (node?.meta.nodeType === "token-set" && newParentId !== undefined) {
-        // Token-sets cannot be nested, reject this move
+      if (!node) continue;
+
+      const nodeType = node.meta.nodeType;
+
+      // Token-sets and modifiers can only be at top level
+      if (
+        (nodeType === "token-set" || nodeType === "token-modifier") &&
+        newParentId !== undefined
+      ) {
         return;
+      }
+
+      // Contexts must have a modifier as parent
+      if (nodeType === "token-context") {
+        if (newParentId === undefined) return;
+        const parentNode = treeState.getNode(newParentId);
+        if (parentNode?.meta.nodeType !== "token-modifier") return;
+      }
+
+      // Groups and tokens must be under sets or groups
+      if (nodeType === "token-group" || nodeType === "token") {
+        if (newParentId !== undefined) {
+          const parentNode = treeState.getNode(newParentId);
+          if (
+            parentNode?.meta.nodeType !== "token-set" &&
+            parentNode?.meta.nodeType !== "token-group"
+          ) {
+            return;
+          }
+        } else {
+          // Groups and tokens cannot be at root level
+          return;
+        }
       }
     }
 
@@ -339,9 +424,11 @@
   <div class="horizontal-container">
     <!-- Left Panel: Design Tokens -->
     <aside class="panel left-panel">
-      <div class="panel-header">
+      <div class="panel-header app-toolbar">
         <AppMenu />
-        <h1 class="a-panel-title">Engramma</h1>
+        <h1 class="a-panel-title">
+          {isConfiguringModifiers ? "Modifiers" : "Engramma"}
+        </h1>
         <div class="toolbar-actions">
           {#if selectedItems.size > 0}
             <button
@@ -356,29 +443,54 @@
               Delete selected items
             </div>
           {/if}
-          <button
-            class="a-button"
-            aria-label="Add set"
-            interestfor="app-add-set-tooltip"
-            onclick={handleAddSet}
-          >
-            <ListPlus size={16} />
-          </button>
-          <div id="app-add-set-tooltip" popover="hint" class="a-tooltip">
-            Add a new token set
-          </div>
-          <button
-            class="a-button"
-            aria-label="Add group"
-            interestfor="app-add-group-tooltip"
-            onclick={handleAddGroup}
-          >
-            <Folder size={16} />
-          </button>
-          <div id="app-add-group-tooltip" popover="hint" class="a-tooltip">
-            Add a new group
-          </div>
-          <AddToken {selectedItems} onTokenAdded={handleTokenAdded} />
+          {#if isConfiguringModifiers}
+            <button
+              class="a-button"
+              aria-label="Add modifier"
+              interestfor="app-add-modifier-tooltip"
+              onclick={addModifier}
+            >
+              <Layers size={16} />
+            </button>
+            <div id="app-add-modifier-tooltip" popover="hint" class="a-tooltip">
+              Add a new modifier
+            </div>
+            <button
+              class="a-button"
+              aria-label="Add context"
+              interestfor="app-add-context-tooltip"
+              onclick={addContext}
+            >
+              <GitBranch size={16} />
+            </button>
+            <div id="app-add-context-tooltip" popover="hint" class="a-tooltip">
+              Add a new context
+            </div>
+          {:else}
+            <button
+              class="a-button"
+              aria-label="Add set"
+              interestfor="app-add-set-tooltip"
+              onclick={addSet}
+            >
+              <ListPlus size={16} />
+            </button>
+            <div id="app-add-set-tooltip" popover="hint" class="a-tooltip">
+              Add a new token set
+            </div>
+            <button
+              class="a-button"
+              aria-label="Add group"
+              interestfor="app-add-group-tooltip"
+              onclick={addGroup}
+            >
+              <Folder size={16} />
+            </button>
+            <div id="app-add-group-tooltip" popover="hint" class="a-tooltip">
+              Add a new group
+            </div>
+            <AddToken {selectedItems} onTokenAdded={handleTokenAdded} />
+          {/if}
         </div>
       </div>
 
@@ -474,12 +586,32 @@
             {@render treeItemEditorButton(item.id)}
           </div>
         {/if}
+
+        {#if node?.meta.nodeType === "token-modifier"}
+          <div class="token">
+            <div class="token-icon">
+              <Layers size={16} />
+            </div>
+            <span class="token-name">{item.name}</span>
+            {@render treeItemEditorButton(item.id)}
+          </div>
+        {/if}
+
+        {#if node?.meta.nodeType === "token-context"}
+          <div class="token">
+            <div class="token-icon">
+              <GitBranch size={16} />
+            </div>
+            <span class="token-name">{item.name}</span>
+            {@render treeItemEditorButton(item.id)}
+          </div>
+        {/if}
       {/snippet}
 
       <div class="tokens-panel">
         <TreeView
           id="tokens-tree"
-          label="Design Tokens"
+          label={isConfiguringModifiers ? "Modifiers" : "Design Tokens"}
           data={treeData}
           {selectedItems}
           {expandedItems}
@@ -496,28 +628,38 @@
             }
           }}
           canAcceptChildren={(targetId, items) => {
-            // only set can be dropped into root
             if (!targetId) {
-              return items.every(
-                (itemId) =>
-                  treeState.getNode(itemId)?.meta.nodeType === "token-set",
-              );
-            }
-            const target = targetId ? treeState.getNode(targetId) : undefined;
-            // groups and sets accepts only other groups and tokens
-            if (
-              target?.meta.nodeType === "token-set" ||
-              target?.meta.nodeType === "token-group"
-            ) {
+              // Root level constraints based on mode
               return items.every((itemId) => {
                 const node = treeState.getNode(itemId);
-                return (
-                  node?.meta.nodeType === "token-group" ||
-                  node?.meta.nodeType === "token"
-                );
+                const nodeType = node?.meta.nodeType;
+                return isConfiguringModifiers
+                  ? nodeType === "token-modifier"
+                  : nodeType === "token-set";
               });
             }
-            // tokens do not accept anything
+
+            const target = treeState.getNode(targetId);
+            const targetType = target?.meta.nodeType;
+
+            // token-set and token-group accept groups and tokens
+            if (targetType === "token-set" || targetType === "token-group") {
+              return items.every((itemId) => {
+                const node = treeState.getNode(itemId);
+                const nodeType = node?.meta.nodeType;
+                return nodeType === "token-group" || nodeType === "token";
+              });
+            }
+
+            // token-modifier accepts only token-context
+            if (targetType === "token-modifier") {
+              return items.every((itemId) => {
+                const node = treeState.getNode(itemId);
+                return node?.meta.nodeType === "token-context";
+              });
+            }
+
+            // Other node types (token, token-context) don't accept children
             return false;
           }}
           onMove={handleMove}
@@ -529,9 +671,46 @@
 
     <!-- Right Panel: CSS Variables / JSON -->
     <main class="panel right-panel">
-      <div class="panel-header"><!-- placeholder for sets --></div>
+      <div class="panel-header">
+        <div class="a-tab-scroller">
+          <div class="a-tab-list" role="tablist" aria-label="Modifier contexts">
+            <button
+              role="tab"
+              aria-selected={selectedContextId === undefined &&
+                !isConfiguringModifiers}
+              class="a-tab"
+              onclick={() => {
+                selectedContextId = undefined;
+                isConfiguringModifiers = false;
+              }}
+            >
+              Sets
+            </button>
+            {#each allContexts as context (context.nodeId)}
+              <button
+                role="tab"
+                aria-selected={selectedContextId === context.nodeId}
+                class="a-tab"
+                onclick={() => {
+                  selectedContextId = context.nodeId;
+                  isConfiguringModifiers = false;
+                }}
+              >
+                {context.name}
+              </button>
+            {/each}
+          </div>
+          <button
+            class="a-button a-tab-action"
+            aria-label="Configure modifiers"
+            onclick={() => (isConfiguringModifiers = !isConfiguringModifiers)}
+          >
+            <Settings size={16} />
+          </button>
+        </div>
+      </div>
       <div class="styleguide-panel">
-        <Styleguide {selectedItems} />
+        <Styleguide {selectedItems} {selectedContextId} />
       </div>
     </main>
   </div>
@@ -572,15 +751,18 @@
   }
 
   .panel-header {
+    border-bottom: 1px solid var(--border-color);
+    flex-shrink: 0;
+    background: var(--bg-primary);
+    overflow: hidden;
+  }
+
+  .app-toolbar {
     display: flex;
     justify-content: flex-start;
     align-items: center;
     padding: 0 8px;
-    border-bottom: 1px solid var(--border-color);
-    flex-shrink: 0;
-    background: var(--bg-primary);
     gap: 8px;
-    overflow: hidden;
   }
 
   .toolbar-actions {

--- a/src/app.svelte
+++ b/src/app.svelte
@@ -267,6 +267,21 @@
     }
   };
 
+  const resetSelectionToFirstNode = () => {
+    selectedItems.clear();
+    expandedItems.clear();
+
+    const allRootNodes = treeState.getChildren(undefined);
+    const firstNode = isConfiguringModifiers
+      ? allRootNodes.find((n) => n.meta.nodeType === "token-modifier")
+      : allRootNodes.find((n) => n.meta.nodeType === "token-set");
+
+    if (firstNode) {
+      selectedItems.add(firstNode.nodeId);
+      expandedItems.add(firstNode.nodeId);
+    }
+  };
+
   const handleMove = (
     itemIds: string[],
     newParentId: undefined | string,
@@ -681,7 +696,10 @@
               class="a-tab"
               onclick={() => {
                 selectedContextId = undefined;
-                isConfiguringModifiers = false;
+                if (isConfiguringModifiers) {
+                  isConfiguringModifiers = false;
+                  resetSelectionToFirstNode();
+                }
               }}
             >
               Sets
@@ -693,7 +711,10 @@
                 class="a-tab"
                 onclick={() => {
                   selectedContextId = context.nodeId;
-                  isConfiguringModifiers = false;
+                  if (isConfiguringModifiers) {
+                    isConfiguringModifiers = false;
+                    resetSelectionToFirstNode();
+                  }
                 }}
               >
                 {context.name}
@@ -703,7 +724,11 @@
           <button
             class="a-button a-tab-action"
             aria-label="Configure modifiers"
-            onclick={() => (isConfiguringModifiers = !isConfiguringModifiers)}
+            onclick={() => {
+              isConfiguringModifiers = !isConfiguringModifiers;
+              selectedContextId = undefined;
+              resetSelectionToFirstNode();
+            }}
           >
             <Settings size={16} />
           </button>

--- a/src/app.svelte
+++ b/src/app.svelte
@@ -54,6 +54,7 @@
     resolveTokenValue,
     treeState,
     type TreeNodeMeta,
+    getNodePath,
   } from "./state.svelte";
   import { serializeColor } from "./color";
   import type { Value } from "./schema";
@@ -89,6 +90,7 @@
     rootNodes.length ? [rootNodes[0].nodeId] : [],
   );
 
+  // Build tree item recursively
   const buildTreeItem = (node: TreeNode<TreeNodeMeta>): TreeItem => {
     const children = treeState.getChildren(node.nodeId);
     return {
@@ -96,10 +98,83 @@
       parentId: node.parentId,
       name: node.meta.name,
       children: children.map(buildTreeItem),
+      isOwned: true,
     };
   };
 
-  const treeData = $derived(rootNodes.map(buildTreeItem));
+  // Build merged tree for context view
+  const buildMergedTreeItem = (
+    node: TreeNode<TreeNodeMeta>,
+    contextTokens: Map<string, TreeNode<TreeNodeMeta>>,
+  ): TreeItem => {
+    const children = treeState.getChildren(node.nodeId);
+    const contextToken = contextTokens.get(node.nodeId);
+    const isOwned = contextToken !== undefined;
+
+    // Use context token if available, otherwise use base token
+    const displayNode = contextToken ?? node;
+
+    return {
+      id: displayNode.nodeId,
+      parentId: displayNode.parentId,
+      name: displayNode.meta.name,
+      children: children.map((child) =>
+        buildMergedTreeItem(child, contextTokens),
+      ),
+      isOwned,
+    };
+  };
+
+  const treeData = $derived.by(() => {
+    if (selectedContextId) {
+      // Get all base set tokens
+      const baseNodes = treeState.getBaseNodes();
+
+      // Get all tokens in the selected context
+      const contextTokens = new Map<string, TreeNode<TreeNodeMeta>>();
+      const contextTokenList = treeState.getAllTokensUnder(selectedContextId);
+
+      // Build a map of paths to context tokens
+      for (const token of contextTokenList) {
+        const path = getNodePath(token, treeState.nodes()).slice(1).join("/");
+        contextTokens.set(path, token);
+      }
+
+      // Merge: show base sets but indicate which tokens are owned by context
+      return baseNodes.map((setNode) => {
+        const children = treeState.getChildren(setNode.nodeId);
+        return {
+          id: setNode.nodeId,
+          parentId: setNode.parentId,
+          name: setNode.meta.name,
+          children: children.map((child) => {
+            // For each child, check if it's in the context
+            const childPath = getNodePath(child, treeState.nodes())
+              .slice(1)
+              .join("/");
+            const contextToken = contextTokens.get(childPath);
+
+            if (child.meta.nodeType === "token") {
+              const isOwned = contextToken !== undefined;
+              return {
+                id: isOwned ? contextToken.nodeId : child.nodeId,
+                parentId: isOwned ? contextToken.parentId : child.parentId,
+                name: child.meta.name,
+                children: [],
+                isOwned,
+              };
+            }
+
+            // For groups, recursively build with context awareness
+            return buildMergedTreeItem(child, contextTokens);
+          }),
+          isOwned: true,
+        };
+      });
+    }
+
+    return rootNodes.map(buildTreeItem);
+  });
   const expandedItems = new SvelteSet(
     // svelte-ignore state_referenced_locally
     rootNodes.length ? [rootNodes[0].nodeId] : [],
@@ -458,53 +533,63 @@
               Delete selected items
             </div>
           {/if}
-          {#if isConfiguringModifiers}
-            <button
-              class="a-button"
-              aria-label="Add modifier"
-              interestfor="app-add-modifier-tooltip"
-              onclick={addModifier}
-            >
-              <Layers size={16} />
-            </button>
-            <div id="app-add-modifier-tooltip" popover="hint" class="a-tooltip">
-              Add a new modifier
-            </div>
-            <button
-              class="a-button"
-              aria-label="Add context"
-              interestfor="app-add-context-tooltip"
-              onclick={addContext}
-            >
-              <GitBranch size={16} />
-            </button>
-            <div id="app-add-context-tooltip" popover="hint" class="a-tooltip">
-              Add a new context
-            </div>
-          {:else}
-            <button
-              class="a-button"
-              aria-label="Add set"
-              interestfor="app-add-set-tooltip"
-              onclick={addSet}
-            >
-              <ListPlus size={16} />
-            </button>
-            <div id="app-add-set-tooltip" popover="hint" class="a-tooltip">
-              Add a new token set
-            </div>
-            <button
-              class="a-button"
-              aria-label="Add group"
-              interestfor="app-add-group-tooltip"
-              onclick={addGroup}
-            >
-              <Folder size={16} />
-            </button>
-            <div id="app-add-group-tooltip" popover="hint" class="a-tooltip">
-              Add a new group
-            </div>
-            <AddToken {selectedItems} onTokenAdded={handleTokenAdded} />
+          {#if !selectedContextId}
+            {#if isConfiguringModifiers}
+              <button
+                class="a-button"
+                aria-label="Add modifier"
+                interestfor="app-add-modifier-tooltip"
+                onclick={addModifier}
+              >
+                <Layers size={16} />
+              </button>
+              <div
+                id="app-add-modifier-tooltip"
+                popover="hint"
+                class="a-tooltip"
+              >
+                Add a new modifier
+              </div>
+              <button
+                class="a-button"
+                aria-label="Add context"
+                interestfor="app-add-context-tooltip"
+                onclick={addContext}
+              >
+                <GitBranch size={16} />
+              </button>
+              <div
+                id="app-add-context-tooltip"
+                popover="hint"
+                class="a-tooltip"
+              >
+                Add a new context
+              </div>
+            {:else}
+              <button
+                class="a-button"
+                aria-label="Add set"
+                interestfor="app-add-set-tooltip"
+                onclick={addSet}
+              >
+                <ListPlus size={16} />
+              </button>
+              <div id="app-add-set-tooltip" popover="hint" class="a-tooltip">
+                Add a new token set
+              </div>
+              <button
+                class="a-button"
+                aria-label="Add group"
+                interestfor="app-add-group-tooltip"
+                onclick={addGroup}
+              >
+                <Folder size={16} />
+              </button>
+              <div id="app-add-group-tooltip" popover="hint" class="a-tooltip">
+                Add a new group
+              </div>
+              <AddToken {selectedItems} onTokenAdded={handleTokenAdded} />
+            {/if}
           {/if}
         </div>
       </div>
@@ -682,7 +767,7 @@
       </div>
     </aside>
 
-    <Editor id="app-node-editor" {selectedItems} />
+    <Editor id="app-node-editor" {selectedItems} {selectedContextId} />
 
     <!-- Right Panel: CSS Variables / JSON -->
     <main class="panel right-panel">

--- a/src/editor.svelte
+++ b/src/editor.svelte
@@ -155,6 +155,17 @@
     return ["mixed"];
   };
 
+  const getModifierContexts = (modifierId: string) => {
+    const contexts: Array<{ nodeId: string; name: string }> = [];
+    const children = treeState.getChildren(modifierId);
+    for (const child of children) {
+      if (child.meta.nodeType === "token-context") {
+        contexts.push({ nodeId: child.nodeId, name: child.meta.name });
+      }
+    }
+    return contexts;
+  };
+
   const updateMeta = (newMeta: Partial<TreeNodeMeta>) => {
     if (node?.meta) {
       treeState.transact((tx) => {
@@ -404,11 +415,21 @@
 <div {id} popover="auto" class="a-popover editor-popover" {...rest}>
   <div class="form-header">
     <h2 class="a-panel-title">
-      {node?.meta.nodeType === "token-set"
-        ? "Token Set"
-        : node?.meta.nodeType === "token-group"
-          ? "Group"
-          : "Token"}
+      {#if node?.meta.nodeType === "token-set"}
+        Set
+      {/if}
+      {#if node?.meta.nodeType === "token-modifier"}
+        Modifier
+      {/if}
+      {#if node?.meta.nodeType === "token-context"}
+        Modifier Context
+      {/if}
+      {#if node?.meta.nodeType === "token-group"}
+        Group
+      {/if}
+      {#if node?.meta.nodeType === "token"}
+        Token
+      {/if}
     </h2>
     <button
       class="a-button"
@@ -1097,6 +1118,33 @@
               updateMeta({ value });
             }}
           />
+        </div>
+      {/if}
+
+      {#if node?.meta.nodeType === "token-modifier"}
+        {@const contexts = getModifierContexts(node.nodeId)}
+        <div class="form-group">
+          <label class="a-label" for="default-context-select"
+            >Default Context</label
+          >
+          <select
+            id="default-context-select"
+            class="a-field"
+            value={node.meta.default?.ref ?? ""}
+            onchange={(e) => {
+              const value = e.currentTarget.value;
+              updateMeta({
+                default: value ? { ref: value } : undefined,
+              });
+            }}
+          >
+            <option class="a-item" value="">None</option>
+            {#each contexts as context}
+              <option class="a-item" value={context.nodeId}>
+                {context.name}
+              </option>
+            {/each}
+          </select>
         </div>
       {/if}
     </div>

--- a/src/editor.svelte
+++ b/src/editor.svelte
@@ -12,6 +12,9 @@
     findTokenType,
     type TreeNodeMeta,
     resolveRawValue,
+    getNodePath,
+    findNodeAtPath,
+    type TokenMeta,
   } from "./state.svelte";
   import { parseColor, serializeColor } from "./color";
   import type {
@@ -31,10 +34,12 @@
   let {
     id,
     selectedItems,
+    selectedContextId,
     ...rest
   }: HTMLAttributes<HTMLDivElement> & {
     id: string;
     selectedItems: SvelteSet<string>;
+    selectedContextId?: string;
   } = $props();
 
   const fontWeightMap: Record<string, number> = {
@@ -167,7 +172,27 @@
   };
 
   const updateMeta = (newMeta: Partial<TreeNodeMeta>) => {
-    if (node?.meta) {
+    if (!node?.meta) return;
+
+    // Check if we're editing a token in a context that's not owned by it
+    const isEditingInheritedToken =
+      selectedContextId &&
+      node.meta.nodeType === "token" &&
+      !isTokenOwnedByContext(node.nodeId, selectedContextId);
+
+    if (isEditingInheritedToken) {
+      // Create a context override instead of editing the base token
+      const newTokenId = treeState.createContextOverride(
+        selectedContextId,
+        node.nodeId,
+        newMeta as Partial<TokenMeta>,
+      );
+
+      // Update selection to the new override token
+      selectedItems.clear();
+      selectedItems.add(newTokenId);
+    } else {
+      // Normal update
       treeState.transact((tx) => {
         const updatedNode = {
           ...node,
@@ -176,6 +201,33 @@
         tx.set(updatedNode);
       });
     }
+  };
+
+  /**
+   * Check if a token is directly owned by a context (not inherited)
+   */
+  const isTokenOwnedByContext = (
+    tokenId: string,
+    contextId: string,
+  ): boolean => {
+    const tokenNode = treeState.getNode(tokenId);
+    if (!tokenNode) return false;
+
+    // Walk up the parent chain to see if we reach the context
+    let currentId: string | undefined = tokenId;
+    while (currentId) {
+      const currentNode = treeState.getNode(currentId);
+      if (!currentNode) break;
+
+      // If we found the context as a parent, this token is owned by it
+      if (currentNode.nodeId === contextId) {
+        return true;
+      }
+
+      currentId = currentNode.parentId;
+    }
+
+    return false;
   };
 
   const handleNameChange = (newName: string) => {

--- a/src/export-dialog.svelte
+++ b/src/export-dialog.svelte
@@ -83,7 +83,7 @@
       </button>
     </div>
     <button
-      class="a-button dialog-close"
+      class="a-button a-tab-action"
       aria-label="Close"
       commandfor="export-dialog"
       command="close"
@@ -131,12 +131,6 @@
     &::backdrop {
       background: rgba(0, 0, 0, 0.5);
     }
-  }
-
-  .dialog-close {
-    position: sticky;
-    right: 8px;
-    margin: 0 8px;
   }
 
   .code-panel {

--- a/src/state.svelte.ts
+++ b/src/state.svelte.ts
@@ -1,5 +1,6 @@
 import * as z from "zod/mini";
 import { createSubscriber } from "svelte/reactivity";
+import { generateKeyBetween } from "fractional-indexing";
 import { TreeStore, type Transaction, type TreeNode } from "./store";
 import {
   type RawValue,
@@ -296,6 +297,54 @@ export const resolveTokenValue = (
 };
 
 /**
+ * Get the path of a node by traversing up to the root
+ * Returns array of node names from root to the node
+ */
+export const getNodePath = (
+  node: TreeNode<TreeNodeMeta>,
+  nodes: Map<string, TreeNode<TreeNodeMeta>>,
+): string[] => {
+  const path: string[] = [];
+  let current: TreeNode<TreeNodeMeta> | undefined = node;
+
+  while (current) {
+    path.unshift(current.meta.name);
+    if (current.parentId) {
+      current = nodes.get(current.parentId);
+    } else {
+      current = undefined;
+    }
+  }
+
+  return path;
+};
+
+/**
+ * Find a node at a given path under a parent context
+ * Returns the node or undefined if not found
+ */
+export const findNodeAtPath = (
+  contextId: string,
+  path: string[],
+  nodes: Map<string, TreeNode<TreeNodeMeta>>,
+): TreeNode<TreeNodeMeta> | undefined => {
+  let currentParentId: string | undefined = contextId;
+
+  for (const segment of path) {
+    const children = Array.from(nodes.values()).filter(
+      (n) => n.parentId === currentParentId,
+    );
+    const match = children.find((n) => n.meta.name === segment);
+    if (!match) {
+      return undefined;
+    }
+    currentParentId = match.nodeId;
+  }
+
+  return currentParentId ? nodes.get(currentParentId) : undefined;
+};
+
+/**
  * Check if setting an alias would create a circular dependency
  * Returns true if the alias would be safe (no circular dependency)
  * Returns false if the alias would create a circular dependency
@@ -344,6 +393,50 @@ export const isAliasCircular = (
   }
 
   return false; // No circular dependency
+};
+
+/**
+ * Create a path of groups in a context, returning the leaf node ID
+ * Creates intermediate groups if they don't exist
+ */
+export const createPathInContext = (
+  contextId: string,
+  path: string[],
+  tx: Transaction<TreeNodeMeta>,
+  nodes: Map<string, TreeNode<TreeNodeMeta>>,
+): string => {
+  let currentParentId: string = contextId;
+
+  for (const segment of path) {
+    // Check if a group with this name already exists
+    const existingGroup = Array.from(nodes.values()).find(
+      (n) =>
+        n.parentId === currentParentId &&
+        n.meta.nodeType === "token-group" &&
+        n.meta.name === segment,
+    );
+
+    if (existingGroup) {
+      currentParentId = existingGroup.nodeId;
+    } else {
+      // Create new group
+      const newGroup: TreeNode<TreeNodeMeta> = {
+        nodeId: crypto.randomUUID(),
+        parentId: currentParentId,
+        index: generateKeyBetween(null, null),
+        meta: {
+          nodeType: "token-group",
+          name: segment,
+        } as GroupMeta,
+      };
+      tx.set(newGroup);
+      currentParentId = newGroup.nodeId;
+      // Update nodes map for subsequent lookups
+      nodes.set(newGroup.nodeId, newGroup);
+    }
+  }
+
+  return currentParentId;
 };
 
 export type TreeNodeMeta =
@@ -402,6 +495,108 @@ export class TreeState<Meta> {
   getNextSibling(nodeId: string): TreeNode<Meta> | undefined {
     this.#subscribe();
     return this.#store.getNextSibling(nodeId);
+  }
+
+  /**
+   * Get all base set nodes (token-set children excluding modifiers)
+   */
+  getBaseNodes(): TreeNode<Meta>[] {
+    this.#subscribe();
+    return this.#store
+      .getChildren(undefined)
+      .filter((n) => (n.meta as TreeNodeMeta).nodeType === "token-set");
+  }
+
+  /**
+   * Get all tokens under a parent (recursive)
+   */
+  getAllTokensUnder(parentId: string | undefined): TreeNode<Meta>[] {
+    this.#subscribe();
+    const tokens: TreeNode<Meta>[] = [];
+    const collect = (id: string | undefined) => {
+      const children = this.#store.getChildren(id);
+      for (const child of children) {
+        const meta = child.meta as TreeNodeMeta;
+        if (meta.nodeType === "token") {
+          tokens.push(child);
+        } else if (
+          meta.nodeType === "token-group" ||
+          meta.nodeType === "token-set" ||
+          meta.nodeType === "token-context"
+        ) {
+          collect(child.nodeId);
+        }
+      }
+    };
+    collect(parentId);
+    return tokens;
+  }
+
+  /**
+   * Create a token override in a context based on a source token
+   * Returns the new token's nodeId
+   */
+  createContextOverride(
+    contextId: string,
+    sourceTokenId: string,
+    tokenData: Partial<TokenMeta>,
+  ): string {
+    const nodes = this.#store.nodes();
+    const sourceToken = nodes.get(sourceTokenId);
+    if (
+      !sourceToken ||
+      (sourceToken.meta as TreeNodeMeta).nodeType !== "token"
+    ) {
+      throw new Error("Source token not found");
+    }
+
+    const sourceMeta = sourceToken.meta as TokenMeta;
+
+    // Get the path of the source token (excluding the root set name)
+    const fullPath = getNodePath(
+      sourceToken as TreeNode<TreeNodeMeta>,
+      nodes as Map<string, TreeNode<TreeNodeMeta>>,
+    );
+    // Remove the root set name from the path
+    const pathWithoutRoot = fullPath.slice(1, -1); // Exclude root and token name
+
+    let newTokenId: string | undefined;
+
+    this.transact((tx) => {
+      // Create the path in the context
+      const parentId = createPathInContext(
+        contextId,
+        pathWithoutRoot,
+        tx as Transaction<TreeNodeMeta>,
+        nodes as Map<string, TreeNode<TreeNodeMeta>>,
+      );
+
+      // Generate index for the new token
+      const siblings = this.#store.getChildren(parentId);
+      const lastIndex =
+        siblings.at(-1)?.index ?? generateKeyBetween(null, null);
+      const newIndex = generateKeyBetween(lastIndex, null);
+
+      // Create the token override
+      const newToken: TreeNode<TreeNodeMeta> = {
+        nodeId: crypto.randomUUID(),
+        parentId,
+        index: newIndex,
+        meta: {
+          nodeType: "token",
+          name: sourceMeta.name,
+          description: tokenData.description ?? sourceMeta.description,
+          deprecated: tokenData.deprecated ?? sourceMeta.deprecated,
+          type: tokenData.type ?? sourceMeta.type,
+          value: tokenData.value ?? sourceMeta.value,
+        } as TokenMeta,
+      };
+
+      tx.set(newToken as TreeNode<Meta>);
+      newTokenId = newToken.nodeId;
+    });
+
+    return newTokenId!;
   }
 }
 

--- a/src/styleguide.svelte
+++ b/src/styleguide.svelte
@@ -22,7 +22,11 @@
   } from "./css-variables";
   import CopyButton from "./copy-button.svelte";
 
-  const { selectedItems }: { selectedItems: Set<string> } = $props();
+  const {
+    selectedItems,
+    selectedContextId,
+  }: { selectedItems: Set<string>; selectedContextId: string | undefined } =
+    $props();
 
   const visibleNodes = $derived.by(() => {
     const visibleNodes = new Set<string>();

--- a/src/tree-view.svelte
+++ b/src/tree-view.svelte
@@ -4,6 +4,7 @@
     parentId: undefined | string;
     name: string;
     children: TreeItem[];
+    isOwned?: boolean;
   };
 </script>
 
@@ -479,7 +480,7 @@
 </script>
 
 {#snippet item(itemData: TreeItem, level: number, position: number)}
-  {@const { id, name, children } = itemData}
+  {@const { id, name, children, isOwned } = itemData}
   {@const isEditing = editingItemId === id}
   <div
     id={getItemElementId(id)}
@@ -492,6 +493,7 @@
     data-hovered={hoveredItemId === id}
     data-position={position}
     data-name={name}
+    data-owned={isOwned ?? true}
   >
     <div
       class="node"
@@ -618,6 +620,10 @@
 
     &[data-dragging="true"] {
       --tree-view-node-opacity: 0.5;
+    }
+
+    &[data-owned="false"] {
+      --tree-view-node-opacity: 0.4;
     }
   }
 


### PR DESCRIPTION
Adds a UI for navigating and managing modifier nodes in the design tokens tree. This enables users to create and configure token modifiers with multiple contexts, switch between different views via tab navigation, and properly constrain drag-and-drop operations for the new node types.

- Navigation: Added tab-based navigation in the right panel to switch between token sets and modifier contexts
- Modifier Mode: Added toggle to switch between "Sets" and "Modifiers" configuration modes
- Node Management: Added support for creating token-modifier and token-context nodes with proper parent constraints
- Tree View: Updated drag-and-drop validation to handle modifier hierarchy constraints
- Editor: Added editor support for modifier and context nodes, including default context selector
- UI: Added appropriate icons (Layers, GitBranch) for modifier-related nodes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mode switching between Design Tokens and Modifiers with contextual left/right panels
  * Modifier context management, create/override flows, and ability to set a Default Context from the editor
  * Tree view shows modifiers, contexts, ownership state, and enforces valid nesting/drag rules
  * Styleguide and Editor accept a selected context so previews and edits reflect the chosen context

* **Style**
  * Updated toolbar and close-button styling for improved placement and visual consistency

* **Chores**
  * Simplified HTML/CSS bootstrapping and some layout refinements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->